### PR TITLE
Fix Dropdown Icon

### DIFF
--- a/src/DropDown.tsx
+++ b/src/DropDown.tsx
@@ -234,7 +234,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
                 theme={theme}
                 right={
                   <TextInput.Icon
-                    name={visible ? "menu-up" : "menu-down"}
+                    icon={visible ? "menu-up" : "menu-down"}
                     disabled={disabled}
                     forceTextInputFocus={false}
                     color={iconColor}


### PR DESCRIPTION
Implements a fix from https://github.com/fateh999/react-native-paper-dropdown/issues/91 that fixes an issue with the dropdown icon not rendering.